### PR TITLE
Fix block calculations and saving blacklistedWorlds. fix #19 #21

### DIFF
--- a/src/main/java/com/flemmli97/flan/claim/Claim.java
+++ b/src/main/java/com/flemmli97/flan/claim/Claim.java
@@ -149,7 +149,7 @@ public class Claim implements IPermissionContainer {
     }
 
     public int getPlane() {
-        return (this.maxX - this.minX) * (this.maxZ - this.minZ);
+        return (this.maxX - this.minX + 1) * (this.maxZ - this.minZ + 1);
     }
 
     /**

--- a/src/main/java/com/flemmli97/flan/config/Config.java
+++ b/src/main/java/com/flemmli97/flan/config/Config.java
@@ -70,9 +70,8 @@ public class Config {
             this.ticksForNextBlock = ConfigHandler.fromJson(obj, "ticksForNextBlock", this.ticksForNextBlock);
             this.minClaimsize = ConfigHandler.fromJson(obj, "minClaimsize", this.minClaimsize);
             this.defaultClaimDepth = ConfigHandler.fromJson(obj, "defaultClaimDepth", this.defaultClaimDepth);
-            JsonArray arr = ConfigHandler.arryFromJson(obj, "blacklistedWorlds");
             this.lenientBlockEntityCheck = ConfigHandler.fromJson(obj, "lenientBlockEntityCheck", this.lenientBlockEntityCheck);
-
+            JsonArray arr = ConfigHandler.arryFromJson(obj, "blacklistedWorlds");
             this.blacklistedWorlds = new String[arr.size()];
             for (int i = 0; i < arr.size(); i++)
                 this.blacklistedWorlds[i] = arr.get(i).getAsString();
@@ -115,6 +114,8 @@ public class Config {
         obj.addProperty("defaultClaimDepth", this.defaultClaimDepth);
         obj.addProperty("lenientBlockEntityCheck", this.lenientBlockEntityCheck);
         JsonArray arr = new JsonArray();
+        for (int i = 0; i < this.blacklistedWorlds.length; i++)
+            arr.add(this.blacklistedWorlds[i]);
         obj.add("blacklistedWorlds", arr);
         obj.addProperty("worldWhitelist", this.worldWhitelist);
         obj.addProperty("claimingItem", Registry.ITEM.getId(this.claimingItem).toString());

--- a/src/main/java/com/flemmli97/flan/event/ItemInteractEvents.java
+++ b/src/main/java/com/flemmli97/flan/event/ItemInteractEvents.java
@@ -28,8 +28,6 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -42,22 +40,6 @@ public class ItemInteractEvents {
             return TypedActionResult.pass(p.getStackInHand(hand));
         ServerPlayerEntity player = (ServerPlayerEntity) p;
         ItemStack stack = player.getStackInHand(hand);
-        if (stack.getItem() == ConfigHandler.config.claimingItem) {
-            HitResult ray = player.rayTrace(64, 0, false);
-            if (ray != null && ray.getType() == HitResult.Type.BLOCK) {
-                claimLandHandling(player, ((BlockHitResult) ray).getBlockPos());
-                return TypedActionResult.success(stack);
-            }
-            return TypedActionResult.pass(stack);
-        }
-        if (stack.getItem() == ConfigHandler.config.inspectionItem) {
-            HitResult ray = player.rayTrace(32, 0, false);
-            if (ray != null && ray.getType() == HitResult.Type.BLOCK) {
-                inspect(player, ((BlockHitResult) ray).getBlockPos());
-                return TypedActionResult.success(stack);
-            }
-            return TypedActionResult.pass(stack);
-        }
         ClaimStorage storage = ClaimStorage.get((ServerWorld) world);
         BlockPos pos = player.getBlockPos();
         IPermissionContainer claim = storage.getForPermissionCheck(pos);


### PR DESCRIPTION
I have not done much with GitHub and Pull Requests, so hope I did this right.

Here are changes for the calculations of claim size, fixing #19. Along with adding code to save the blacklistedWorlds array into the config file, fixing #21.

(these changed have been tested with 1.16.2, gradle build)