### PR TITLE
removed duplicate claim inspect

### DIFF
--- a/src/main/java/com/flemmli97/flan/event/ItemInteractEvents.java
+++ b/src/main/java/com/flemmli97/flan/event/ItemInteractEvents.java
@@ -28,8 +28,6 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -42,22 +40,6 @@ public class ItemInteractEvents {
             return TypedActionResult.pass(p.getStackInHand(hand));
         ServerPlayerEntity player = (ServerPlayerEntity) p;
         ItemStack stack = player.getStackInHand(hand);
-        if (stack.getItem() == ConfigHandler.config.claimingItem) {
-            HitResult ray = player.rayTrace(64, 0, false);
-            if (ray != null && ray.getType() == HitResult.Type.BLOCK) {
-                claimLandHandling(player, ((BlockHitResult) ray).getBlockPos());
-                return TypedActionResult.success(stack);
-            }
-            return TypedActionResult.pass(stack);
-        }
-        if (stack.getItem() == ConfigHandler.config.inspectionItem) {
-            HitResult ray = player.rayTrace(32, 0, false);
-            if (ray != null && ray.getType() == HitResult.Type.BLOCK) {
-                inspect(player, ((BlockHitResult) ray).getBlockPos());
-                return TypedActionResult.success(stack);
-            }
-            return TypedActionResult.pass(stack);
-        }
         ClaimStorage storage = ClaimStorage.get((ServerWorld) world);
         BlockPos pos = player.getBlockPos();
         IPermissionContainer claim = storage.getForPermissionCheck(pos);


### PR DESCRIPTION
Removed (redundant) raycasting block check/inspect from ItemInteractEvents as this is handled in BlockInteractEvents, causing a double-message in chat when right-clicking a block. Left inpect() method in ItemInteractEvents however.