### PR TITLE
Increase claim particle size

### DIFF
--- a/src/main/java/com/flemmli97/flan/claim/ParticleIndicators.java
+++ b/src/main/java/com/flemmli97/flan/claim/ParticleIndicators.java
@@ -4,16 +4,16 @@ import net.minecraft.particle.DustParticleEffect;
 
 public class ParticleIndicators {
 
-    public static final DustParticleEffect CLAIMCORNER = new DustParticleEffect(194 / 255f, 130 / 255f, 4 / 255f, 1);
-    public static final DustParticleEffect CLAIMMIDDLE = new DustParticleEffect(237 / 255f, 187 / 255f, 38 / 255f, 1);
+    public static final DustParticleEffect CLAIMCORNER = new DustParticleEffect(194 / 255f, 130 / 255f, 4 / 255f, 3);
+    public static final DustParticleEffect CLAIMMIDDLE = new DustParticleEffect(237 / 255f, 187 / 255f, 38 / 255f, 3);
 
-    public static final DustParticleEffect SUBCLAIMCORNER = new DustParticleEffect(125 / 255f, 125 / 255f, 125 / 255f, 1);
-    public static final DustParticleEffect SUBCLAIMMIDDLE = new DustParticleEffect(194 / 255f, 194 / 255f, 194 / 255f, 1);
+    public static final DustParticleEffect SUBCLAIMCORNER = new DustParticleEffect(125 / 255f, 125 / 255f, 125 / 255f, 3);
+    public static final DustParticleEffect SUBCLAIMMIDDLE = new DustParticleEffect(194 / 255f, 194 / 255f, 194 / 255f, 3);
 
-    public static final DustParticleEffect EDITCLAIMCORNER = new DustParticleEffect(12 / 255f, 110 / 255f, 103 / 255f, 1);
-    public static final DustParticleEffect EDITCLAIMMIDDLE = new DustParticleEffect(20 / 255f, 186 / 255f, 175 / 255f, 1);
+    public static final DustParticleEffect EDITCLAIMCORNER = new DustParticleEffect(12 / 255f, 110 / 255f, 103 / 255f, 3);
+    public static final DustParticleEffect EDITCLAIMMIDDLE = new DustParticleEffect(20 / 255f, 186 / 255f, 175 / 255f, 3);
 
-    public static final DustParticleEffect SETCORNER = new DustParticleEffect(18 / 255f, 38 / 255f, 150 / 255f, 1);
+    public static final DustParticleEffect SETCORNER = new DustParticleEffect(18 / 255f, 38 / 255f, 150 / 255f, 3);
 
-    public static final DustParticleEffect OVERLAPCLAIM = DustParticleEffect.RED;
+    public static final DustParticleEffect OVERLAPCLAIM = new DustParticleEffect(255 / 255f, 0 / 255f, 0 / 255f, 3);
 }


### PR DESCRIPTION
This is a slightly opinionated PR, but I hope a welcome one. The mod works great, but the claim boundary particles can be hard to see in suboptimal conditions (if the terrain is uneven, or it's a dark area, or the claim is very large). This PR increases the size of the particles by a factor of 3, so that players can quickly and easily locate the boundaries of their claim. Below you can see a comparison image, with the current size on the left, and the PRed size on the right. Thank you for your work on this mod, and I hope this is useful!

![image](https://user-images.githubusercontent.com/6319658/101976506-e3461c00-3c13-11eb-8f6c-29f5151822cf.png)
