### PR TITLE
Fix icon link in mod json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "sources": "https://github.com/Flemmli97/Flan"
   },
   "license": "ARR",
-  "icon": "assets/modid/icon.png",
+  "icon": "assets/flan/icon.png",
   "environment": "*",
   "entrypoints": {
     "main": [


### PR DESCRIPTION
The mod json defines the path to the icon as `assets/modid/icon.png`, which I assume is because it was never changed from the default value.