### PR TITLE
Fix permissions suggestions to only suggest completions of already typed text

### DIFF
--- a/src/main/java/com/flemmli97/flan/commands/CommandClaim.java
+++ b/src/main/java/com/flemmli97/flan/commands/CommandClaim.java
@@ -37,6 +37,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -495,14 +496,15 @@ public class CommandClaim {
         ServerWorld world = context.getSource().getWorld();
         Claim claim = ClaimStorage.get(world).getClaimAt(new BlockPos(context.getSource().getPosition()));
         boolean admin = claim != null && claim.isAdminClaim();
+        List<String> allowedPerms = new ArrayList<>();
         for (ClaimPermission perm : PermissionRegistry.getPerms()) {
             if (!admin && ConfigHandler.config.globallyDefined(world, perm)) {
                 continue;
             }
             if (!group || !PermissionRegistry.globalPerms().contains(perm))
-                build.suggest(perm.id);
+                allowedPerms.add(perm.id);
         }
-        return build.buildFuture();
+        return CommandSource.suggestMatching(allowedPerms, build);
     }
 
     private static int editGlobalPerm(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {


### PR DESCRIPTION
For example, typing `BE` will now suggest only `BEACON` and `BED`, instead of `ANIMALINTERACT`, `ANVIL`, `ARMORSTAND`...