### PR TITLE
Fix incompatibility with BLAST bombs

### DIFF
--- a/fabric/src/main/java/io/github/flemmli97/flan/fabric/mixin/CustomExplosionMixin.java
+++ b/fabric/src/main/java/io/github/flemmli97/flan/fabric/mixin/CustomExplosionMixin.java
@@ -1,0 +1,29 @@
+package io.github.flemmli97.flan.fabric.mixin;
+
+import io.github.flemmli97.flan.event.WorldEvents;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Explosion;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = "ladysnake.blast.common.world.CustomExplosion")
+public abstract class CustomExplosionMixin {
+    @Shadow
+    @Final
+    private Level world;
+
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(method = "explode", at = @At("TAIL"))
+    private void explosionHook(CallbackInfo info) {
+        if (this.world instanceof ServerLevel world) {
+            WorldEvents.modifyExplosion((Explosion) (Object) this, world);
+        }
+    }
+}

--- a/fabric/src/main/resources/flan.fabric.mixins.json
+++ b/fabric/src/main/resources/flan.fabric.mixins.json
@@ -17,7 +17,9 @@
     "FabricFireMixin",
     "LightningHitMixin",
     "WorldSaveHandlerMixin",
-    "PlayerManagerMixin"
+    "PlayerManagerMixin",
+
+    "CustomExplosionMixin"
   ],
   "server": [
   ],


### PR DESCRIPTION
Bombs in BLAST use a custom subclass of `Explosion`, and as such, don't use `ServerLevel#explode`. They do, however, [still use `Explosion#explode`](https://github.com/Ladysnake/BLAST/blob/3a2da43fe92ab1cb5b47a923bb2724881d68cdb8/src/main/java/ladysnake/blast/common/entity/BombEntity.java#L133), hence the modified mixin.