### PR TITLE
feat: display remaining claim blocks

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/api/data/IPlayerData.java
+++ b/common/src/main/java/io/github/flemmli97/flan/api/data/IPlayerData.java
@@ -10,6 +10,8 @@ public interface IPlayerData {
 
     int usedClaimBlocks();
 
+    int remainingClaimBlocks();
+
     void setAdditionalClaims(int amount);
 
     default boolean canUseClaimBlocks(int amount) {

--- a/common/src/main/java/io/github/flemmli97/flan/claim/ClaimStorage.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/ClaimStorage.java
@@ -107,7 +107,7 @@ public class ClaimStorage implements IPermissionStorage {
             data.updateScoreboard();
             player.displayClientMessage(PermHelper.simpleColoredText(ConfigHandler.langManager.get("claimCreateSuccess"), ChatFormatting.GOLD), false);
             player.displayClientMessage(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
-                    data.getClaimBlocks(), data.getAdditionalClaims(), data.usedClaimBlocks()), ChatFormatting.GOLD), false);
+                    data.getClaimBlocks(), data.getAdditionalClaims(), data.usedClaimBlocks(), data.remainingClaimBlocks()), ChatFormatting.GOLD), false);
             return true;
         }
         PlayerClaimData data = PlayerClaimData.get(player);
@@ -202,7 +202,7 @@ public class ClaimStorage implements IPermissionStorage {
                 ((PlayerClaimData) newData).updateScoreboard();
             player.displayClientMessage(PermHelper.simpleColoredText(ConfigHandler.langManager.get("resizeSuccess"), ChatFormatting.GOLD), false);
             player.displayClientMessage(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
-                    newData.getClaimBlocks(), newData.getAdditionalClaims(), newData.usedClaimBlocks()), ChatFormatting.GOLD), false);
+                    newData.getClaimBlocks(), newData.getAdditionalClaims(), newData.usedClaimBlocks(), data.remainingClaimBlocks()), ChatFormatting.GOLD), false);
             return true;
         }
         player.displayClientMessage(PermHelper.simpleColoredText(ConfigHandler.langManager.get("notEnoughBlocks"), ChatFormatting.RED), false);

--- a/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
@@ -444,11 +444,11 @@ public class CommandClaim {
             if (player != null) {
                 PlayerClaimData data = PlayerClaimData.get(player);
                 context.getSource().sendSuccess(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
-                        data.getClaimBlocks(), data.getAdditionalClaims(), data.usedClaimBlocks()), ChatFormatting.GOLD), false);
+                        data.getClaimBlocks(), data.getAdditionalClaims(), data.usedClaimBlocks(), data.remainingClaimBlocks()), ChatFormatting.GOLD), false);
             } else {
                 OfflinePlayerData data = new OfflinePlayerData(server, of);
                 context.getSource().sendSuccess(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
-                        data.claimBlocks, data.getAdditionalClaims(), data.usedClaimBlocks()), ChatFormatting.GOLD), false);
+                        data.claimBlocks, data.getAdditionalClaims(), data.usedClaimBlocks(), data.remainingClaimBlocks()), ChatFormatting.GOLD), false);
             }
         }
         context.getSource().sendSuccess(PermHelper.simpleColoredText(ConfigHandler.langManager.get("listClaims"), ChatFormatting.GOLD), false);

--- a/common/src/main/java/io/github/flemmli97/flan/config/LangManager.java
+++ b/common/src/main/java/io/github/flemmli97/flan/config/LangManager.java
@@ -39,7 +39,7 @@ public class LangManager {
         this.defaultTranslation.put("noClaim", "There is no claim here.");
         this.defaultTranslation.put("inspectBlockOwner", "This is %1$s's claim");
         this.defaultTranslation.put("inspectNoClaim", "Nobody owns this block");
-        this.defaultTranslation.put("claimBlocksFormat", "Claim Blocks: %1$d + (Bonus) %2$d); Used: %3$d");
+        this.defaultTranslation.put("claimBlocksFormat", "Claim Blocks: %1$d + (Bonus) %2$d); Used: %3$d; Remaining %4$d");
         this.defaultTranslation.put("listClaims", "Listing all claims:");
         this.defaultTranslation.put("listAdminClaims", "Listing all admin-claims in %1$s:");
         this.defaultTranslation.put("onlyOnePlayer", "Only one player can be used as argument");

--- a/common/src/main/java/io/github/flemmli97/flan/player/OfflinePlayerData.java
+++ b/common/src/main/java/io/github/flemmli97/flan/player/OfflinePlayerData.java
@@ -84,6 +84,11 @@ public class OfflinePlayerData implements IPlayerData {
     }
 
     @Override
+    public int remainingClaimBlocks() {
+        return this.getClaimBlocks() + this.getAdditionalClaims() - this.usedClaimBlocks();
+    }
+
+    @Override
     public void setAdditionalClaims(int amount) {
         this.additionalClaimBlocks = amount;
         try {

--- a/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
+++ b/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
@@ -134,6 +134,11 @@ public class PlayerClaimData implements IPlayerData {
         return this.calculateUsedClaimBlocks();
     }
 
+    @Override
+    public int remainingClaimBlocks() {
+        return this.getClaimBlocks() + this.getAdditionalClaims() - this.usedClaimBlocks();
+    }
+
     /**
      * To prevent double processing. most notably when right clicking on a block and the block doesnt do anything ->
      * block onUse -> item use. Might be a better way but for now this. But also handles having
@@ -286,7 +291,7 @@ public class PlayerClaimData implements IPlayerData {
         } else if (!this.claimBlockMessage) {
             this.claimBlockMessage = true;
             this.player.displayClientMessage(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
-                    this.getClaimBlocks(), this.getAdditionalClaims(), this.usedClaimBlocks()), ChatFormatting.GOLD), false);
+                    this.getClaimBlocks(), this.getAdditionalClaims(), this.usedClaimBlocks(), this.remainingClaimBlocks()), ChatFormatting.GOLD), false);
         }
         this.actionCooldown--;
         if (--this.trappedTick >= 0) {


### PR DESCRIPTION
Adds a remainingClaimBlocks API function and exposes this info directly in the `claimBlocksFormat` lang format.