### PR TITLE
feat: add claimblock cap

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/platform/integration/permissions/PermissionNodeHandler.java
+++ b/common/src/main/java/io/github/flemmli97/flan/platform/integration/permissions/PermissionNodeHandler.java
@@ -46,6 +46,7 @@ public interface PermissionNodeHandler {
 
     String permClaimBlocks = "flan.claim.blocks.max";
     String permMaxClaims = "flan.claims.amount";
+    String permClaimBlocksCap = "flan.claim.blocks.cap";
 
     PermissionNodeHandler INSTANCE = Flan.getPlatformInstance(PermissionNodeHandler.class,
             "io.github.flemmli97.flan.fabric.platform.integration.permissions.PermissionNodeHandlerImpl",
@@ -60,4 +61,6 @@ public interface PermissionNodeHandler {
     boolean perm(ServerPlayer src, String perm, boolean adminCmd);
 
     boolean permBelowEqVal(ServerPlayer src, String perm, int val, int fallback);
+
+    int permVal(ServerPlayer src, String perm, int fallback);
 }

--- a/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
+++ b/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
@@ -88,7 +88,7 @@ public class PlayerClaimData implements IPlayerData {
 
     @Override
     public int getClaimBlocks() {
-        return PermissionNodeHandler.INSTANCE.permVal(this.player, PermissionNodeHandler.permClaimBlocksCap, this.claimBlocks);
+        return Math.min(this.claimBlocks, PermissionNodeHandler.INSTANCE.permVal(this.player, PermissionNodeHandler.permClaimBlocksCap, this.claimBlocks));
     }
 
     public void setClaimBlocks(int amount) {

--- a/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
+++ b/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
@@ -88,7 +88,7 @@ public class PlayerClaimData implements IPlayerData {
 
     @Override
     public int getClaimBlocks() {
-        return this.claimBlocks;
+        return PermissionNodeHandler.INSTANCE.permVal(this.player, PermissionNodeHandler.permClaimBlocksCap, this.claimBlocks);
     }
 
     public void setClaimBlocks(int amount) {

--- a/fabric/src/main/java/io/github/flemmli97/flan/fabric/platform/integration/permissions/PermissionNodeHandlerImpl.java
+++ b/fabric/src/main/java/io/github/flemmli97/flan/fabric/platform/integration/permissions/PermissionNodeHandlerImpl.java
@@ -37,6 +37,8 @@ public class PermissionNodeHandlerImpl implements PermissionNodeHandler {
         return !adminCmd || src.hasPermissions(ConfigHandler.config.permissionLevel);
     }
 
+
+
     @Override
     public boolean permBelowEqVal(ServerPlayer src, String perm, int val, int fallback) {
         if (Flan.permissionAPI) {
@@ -48,5 +50,16 @@ public class PermissionNodeHandlerImpl implements PermissionNodeHandler {
             return val <= max;
         }
         return val <= fallback;
+    }
+
+    @Override
+    public int permVal(ServerPlayer src, String perm, int fallback) {
+        if (Flan.permissionAPI) {
+            return Options.get(src, perm, fallback, Integer::parseInt);
+        }
+        if (Flan.ftbRanks) {
+            return FTBRanksAPI.getPermissionValue(src, perm).asInteger().orElse(fallback);
+        }
+        return fallback;
     }
 }

--- a/forge/src/main/java/io/github/flemmli97/flan/forge/platform/integration/permissions/PermissionNodeHandlerImpl.java
+++ b/forge/src/main/java/io/github/flemmli97/flan/forge/platform/integration/permissions/PermissionNodeHandlerImpl.java
@@ -31,4 +31,12 @@ public class PermissionNodeHandlerImpl implements PermissionNodeHandler {
         }
         return val <= fallback;
     }
+
+    @Override
+    public int permVal(ServerPlayer src, String perm, int fallback) {
+        if (Flan.ftbRanks) {
+            return FTBRanksAPI.getPermissionValue(src, perm).asInteger().orElse(fallback);
+        }
+        return fallback;
+    }
 }


### PR DESCRIPTION
This adds a permission node to temporarily cap a players max claim blocks, this still allows them to accrue claim blocks under the hood but they're not immediately available.

The use case for this permission node is for servers that have a verification or promotion process, where you have fewer blocks accessible at the start but are still earning them for when you get verified.