### PR TITLE
feat: add bluemap support

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,10 +7,12 @@ configurations {
 }
 
 repositories {
+    maven { url 'https://jitpack.io' }
     maven {
         name = "CurseMaven"
         url "https://www.cursemaven.com"
     }
+
 }
 
 dependencies {
@@ -21,6 +23,7 @@ dependencies {
     shadowCommon group: 'org.yaml', name: 'snakeyaml', version: '1.25'
 
     modImplementation dynmap_fabric
+    implementation 'com.github.BlueMap-Minecraft:BlueMapAPI:v2.2.1'
 }
 
 architectury {

--- a/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
@@ -14,7 +14,7 @@ import io.github.flemmli97.flan.config.Config;
 import io.github.flemmli97.flan.config.ConfigHandler;
 import io.github.flemmli97.flan.platform.ClaimPermissionCheck;
 import io.github.flemmli97.flan.platform.CrossPlatformStuff;
-import io.github.flemmli97.flan.platform.integration.dynmap.DynmapCalls;
+import io.github.flemmli97.flan.platform.integration.webmap.WebmapCalls;
 import io.github.flemmli97.flan.player.LogoutTracker;
 import io.github.flemmli97.flan.player.PlayerClaimData;
 import net.minecraft.ChatFormatting;
@@ -166,7 +166,7 @@ public class Claim implements IPermissionContainer {
     public void setClaimName(String name) {
         this.claimName = name;
         this.setDirty(true);
-        DynmapCalls.changeClaimName(this);
+        WebmapCalls.changeClaimName(this);
     }
 
     public UUID getOwner() {

--- a/common/src/main/java/io/github/flemmli97/flan/claim/ClaimStorage.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/ClaimStorage.java
@@ -14,7 +14,7 @@ import io.github.flemmli97.flan.api.data.IPlayerData;
 import io.github.flemmli97.flan.api.permission.ClaimPermission;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import io.github.flemmli97.flan.config.ConfigHandler;
-import io.github.flemmli97.flan.platform.integration.dynmap.DynmapCalls;
+import io.github.flemmli97.flan.platform.integration.webmap.WebmapCalls;
 import io.github.flemmli97.flan.platform.integration.permissions.PermissionNodeHandler;
 import io.github.flemmli97.flan.player.EnumDisplayType;
 import io.github.flemmli97.flan.player.EnumEditMode;
@@ -155,7 +155,7 @@ public class ClaimStorage implements IPermissionStorage {
             claim.remove();
             claim.getOwnerPlayer().ifPresent(o -> PlayerClaimData.get(o).updateScoreboard());
         }
-        DynmapCalls.removeMarker(claim);
+        WebmapCalls.removeMarker(claim);
         return this.claimUUIDMap.remove(claim.getClaimID()) != null;
     }
 
@@ -277,7 +277,7 @@ public class ClaimStorage implements IPermissionStorage {
             old.add(claim);
             return old;
         });
-        DynmapCalls.addClaimMarker(claim);
+        WebmapCalls.addClaimMarker(claim);
     }
 
     public boolean transferOwner(Claim claim, ServerPlayer player, UUID newOwner) {
@@ -295,7 +295,7 @@ public class ClaimStorage implements IPermissionStorage {
             return old;
         });
         this.dirty.add(claim.getOwner());
-        DynmapCalls.changeClaimOwner(claim);
+        WebmapCalls.changeClaimOwner(claim);
         return true;
     }
 
@@ -305,6 +305,10 @@ public class ClaimStorage implements IPermissionStorage {
 
     public Collection<Claim> getAdminClaims() {
         return ImmutableSet.copyOf(this.playerClaimMap.get(null));
+    }
+
+    public Map<UUID, Set<Claim>> getClaims() {
+        return this.playerClaimMap;
     }
 
     public static int[] getChunkPos(Claim claim) {

--- a/common/src/main/java/io/github/flemmli97/flan/platform/integration/webmap/BluemapIntegration.java
+++ b/common/src/main/java/io/github/flemmli97/flan/platform/integration/webmap/BluemapIntegration.java
@@ -1,0 +1,118 @@
+package io.github.flemmli97.flan.platform.integration.webmap;
+
+import com.mojang.authlib.GameProfile;
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import de.bluecolored.bluemap.api.markers.Marker;
+import de.bluecolored.bluemap.api.markers.MarkerSet;
+import de.bluecolored.bluemap.api.markers.ShapeMarker;
+import de.bluecolored.bluemap.api.math.Color;
+import de.bluecolored.bluemap.api.math.Shape;
+import io.github.flemmli97.flan.claim.Claim;
+import io.github.flemmli97.flan.claim.ClaimStorage;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public class BluemapIntegration {
+    private static final String markerID = "flan.claims", markerLabel = "Claims";
+
+    public static void reg(MinecraftServer server) {
+        BlueMapAPI.onEnable(api -> {
+            for (ServerLevel level : server.getAllLevels()) {
+                api.getWorld(level).ifPresent(world -> {
+                    world.getMaps().forEach(map -> {
+                        MarkerSet markerSet = MarkerSet.builder().label(markerLabel).build();
+                        map.getMarkerSets().put(markerID, markerSet);
+                    });
+                });
+                processClaims(level);
+            }
+            WebmapCalls.bluemapLoaded = true;
+        });
+    }
+
+    public static void processClaims(ServerLevel level) {
+        ClaimStorage claimStorage = ClaimStorage.get(level);
+        Map<UUID, Set<Claim>> claimMap = claimStorage.getClaims();
+        claimMap.forEach((uuid, claims) -> {
+            claims.forEach(BluemapIntegration::addClaimMarker);
+        });
+    }
+
+    public static void addClaimMarker(Claim claim) {
+        BlueMapAPI.getInstance().flatMap(api -> api.getWorld(claim.getWorld())).ifPresent(world -> {
+            for (BlueMapMap map : world.getMaps()) {
+                MarkerSet markerSet = map.getMarkerSets().get(markerID);
+                int[] dim = claim.getDimensions();
+                ShapeMarker marker = ShapeMarker.builder()
+                        .label(claimLabel(claim))
+                        .depthTestEnabled(false)
+                        .shape(Shape.createRect(dim[0], dim[2], dim[1], dim[3]), claim.getWorld().getSeaLevel())
+                        .lineColor(new Color(lineColor(claim.isAdminClaim()), 0.8F))
+                        .lineWidth(3)
+                        .fillColor(new Color(fillColor(claim.isAdminClaim()), 0.2F))
+                        .build();
+                markerSet.put(claim.getClaimID().toString(), marker);
+            }
+        });
+    }
+
+    public static void removeMarker(Claim claim) {
+        BlueMapAPI.getInstance().flatMap(api -> api.getWorld(claim.getWorld())).ifPresent(world -> {
+            for (BlueMapMap map : world.getMaps()) {
+                MarkerSet markerSet = map.getMarkerSets().get(markerID);
+                markerSet.remove(claim.getClaimID().toString());
+            }
+        });
+    }
+
+    public static void changeClaimName(Claim claim) {
+        BlueMapAPI.getInstance().flatMap(api -> api.getWorld(claim.getWorld())).ifPresent(world -> {
+            for (BlueMapMap map : world.getMaps()) {
+                MarkerSet markerSet = map.getMarkerSets().get(markerID);
+                Marker marker = markerSet.get(claim.getClaimID().toString());
+                marker.setLabel(claimLabel(claim));
+            }
+        });
+    }
+
+    public static void changeClaimOwner(Claim claim) {
+        BlueMapAPI.getInstance().flatMap(api -> api.getWorld(claim.getWorld())).ifPresent(world -> {
+            for (BlueMapMap map : world.getMaps()) {
+                MarkerSet markerSet = map.getMarkerSets().get(markerID);
+                Marker marker = markerSet.get(claim.getClaimID().toString());
+                marker.setLabel(claimLabel(claim));
+            }
+        });
+    }
+
+    private static int lineColor(boolean admin) {
+        return admin ? 0xb50909 : 0xffa200;
+    }
+
+    private static int fillColor(boolean admin) {
+        return admin ? 0xff0000 : 0xe0e01d;
+    }
+
+    private static String claimLabel(Claim claim) {
+        String name = claim.getClaimName();
+        if (claim.isAdminClaim()) {
+            if (name == null || name.isEmpty()) {
+                return "Admin Claim";
+            } else {
+                return name + " - " + "Admin Claim";
+            }
+        }
+        Optional<GameProfile> prof = claim.getWorld().getServer().getProfileCache().get(claim.getOwner());
+        if (name == null || name.isEmpty()) {
+            return prof.map(GameProfile::getName).orElse("UNKNOWN") + "'s Claim";
+        } else {
+            return name + " - " + prof.map(GameProfile::getName).orElse("UNKNOWN") + "'s Claim";
+        }
+    }
+}

--- a/common/src/main/java/io/github/flemmli97/flan/platform/integration/webmap/DynmapIntegration.java
+++ b/common/src/main/java/io/github/flemmli97/flan/platform/integration/webmap/DynmapIntegration.java
@@ -1,4 +1,4 @@
-package io.github.flemmli97.flan.platform.integration.dynmap;
+package io.github.flemmli97.flan.platform.integration.webmap;
 
 import com.mojang.authlib.GameProfile;
 import io.github.flemmli97.flan.claim.Claim;
@@ -23,7 +23,7 @@ public class DynmapIntegration {
             public void apiEnabled(DynmapCommonAPI dynmapCommonAPI) {
                 MarkerAPI markerAPI = dynmapCommonAPI.getMarkerAPI();
                 markerSet = markerAPI.createMarkerSet(markerID, markerLabel, dynmapCommonAPI.getMarkerAPI().getMarkerIcons(), false);
-                DynmapCalls.dynmapLoaded = true;
+                WebmapCalls.dynmapLoaded = true;
             }
         });
     }

--- a/common/src/main/java/io/github/flemmli97/flan/platform/integration/webmap/WebmapCalls.java
+++ b/common/src/main/java/io/github/flemmli97/flan/platform/integration/webmap/WebmapCalls.java
@@ -1,28 +1,37 @@
-package io.github.flemmli97.flan.platform.integration.dynmap;
+package io.github.flemmli97.flan.platform.integration.webmap;
 
 import io.github.flemmli97.flan.claim.Claim;
 
-public class DynmapCalls {
+public class WebmapCalls {
 
     public static boolean dynmapLoaded;
+    public static boolean bluemapLoaded;
 
     public static void addClaimMarker(Claim claim) {
         if (dynmapLoaded)
             DynmapIntegration.addClaimMarker(claim);
+        if (bluemapLoaded)
+            BluemapIntegration.addClaimMarker(claim);
     }
 
     public static void removeMarker(Claim claim) {
         if (dynmapLoaded)
             DynmapIntegration.removeMarker(claim);
+        if (bluemapLoaded)
+            BluemapIntegration.removeMarker(claim);
     }
 
     public static void changeClaimName(Claim claim) {
         if (dynmapLoaded)
             DynmapIntegration.changeClaimName(claim);
+        if (bluemapLoaded)
+            BluemapIntegration.changeClaimName(claim);
     }
 
     public static void changeClaimOwner(Claim claim) {
         if (dynmapLoaded)
             DynmapIntegration.changeClaimOwner(claim);
+        if (bluemapLoaded)
+            BluemapIntegration.changeClaimOwner(claim);
     }
 }

--- a/fabric/src/main/java/io/github/flemmli97/flan/fabric/FlanFabric.java
+++ b/fabric/src/main/java/io/github/flemmli97/flan/fabric/FlanFabric.java
@@ -9,7 +9,8 @@ import io.github.flemmli97.flan.event.ItemInteractEvents;
 import io.github.flemmli97.flan.event.PlayerEvents;
 import io.github.flemmli97.flan.event.WorldEvents;
 import io.github.flemmli97.flan.fabric.platform.integration.playerability.PlayerAbilityEvents;
-import io.github.flemmli97.flan.platform.integration.dynmap.DynmapIntegration;
+import io.github.flemmli97.flan.platform.integration.webmap.BluemapIntegration;
+import io.github.flemmli97.flan.platform.integration.webmap.DynmapIntegration;
 import io.github.flemmli97.flan.player.PlayerDataHandler;
 import io.github.flemmli97.flan.scoreboard.ClaimCriterias;
 import net.fabricmc.api.ModInitializer;
@@ -73,6 +74,8 @@ public class FlanFabric implements ModInitializer {
     public static void serverLoad(MinecraftServer server) {
         Flan.lockRegistry(server);
         ConfigHandler.serverLoad(server);
+        if (FabricLoader.getInstance().isModLoaded("bluemap"))
+            BluemapIntegration.reg(server);
     }
 
     public static void serverFinishLoad(MinecraftServer server) {

--- a/forge/src/main/java/io/github/flemmli97/flan/forge/FlanForge.java
+++ b/forge/src/main/java/io/github/flemmli97/flan/forge/FlanForge.java
@@ -6,7 +6,7 @@ import io.github.flemmli97.flan.forge.forgeevent.EntityInteractEventsForge;
 import io.github.flemmli97.flan.forge.forgeevent.ItemInteractEventsForge;
 import io.github.flemmli97.flan.forge.forgeevent.ServerEvents;
 import io.github.flemmli97.flan.forge.forgeevent.WorldEventsForge;
-import io.github.flemmli97.flan.platform.integration.dynmap.DynmapIntegration;
+import io.github.flemmli97.flan.platform.integration.webmap.DynmapIntegration;
 import io.github.flemmli97.flan.scoreboard.ClaimCriterias;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;

--- a/forge/src/main/java/io/github/flemmli97/flan/forge/forgeevent/ServerEvents.java
+++ b/forge/src/main/java/io/github/flemmli97/flan/forge/forgeevent/ServerEvents.java
@@ -4,6 +4,7 @@ import io.github.flemmli97.flan.Flan;
 import io.github.flemmli97.flan.commands.CommandClaim;
 import io.github.flemmli97.flan.config.ConfigHandler;
 import io.github.flemmli97.flan.event.PlayerEvents;
+import io.github.flemmli97.flan.platform.integration.webmap.BluemapIntegration;
 import io.github.flemmli97.flan.player.LogoutTracker;
 import io.github.flemmli97.flan.player.PlayerDataHandler;
 import net.minecraft.world.level.Level;
@@ -12,12 +13,16 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
+import net.minecraftforge.fml.ModList;
 
 public class ServerEvents {
 
     public static void serverStart(ServerAboutToStartEvent event) {
         Flan.lockRegistry(event.getServer());
         ConfigHandler.serverLoad(event.getServer());
+
+        if (ModList.get().isLoaded("bluemap"))
+            BluemapIntegration.reg(event.getServer());
     }
 
     public static void serverFinishLoad(ServerStartedEvent event) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ forge_version=1.19-41.1.0
 # check these on https://fabricmc.net/use
 loader_version=0.14.8
 # Mod Properties
-mod_version=1.8.1.1
+mod_version=1.8.1.4
 maven_group=io.github.flemmli97
 archives_base_name=flan
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ forge_version=1.19-41.1.0
 # check these on https://fabricmc.net/use
 loader_version=0.14.8
 # Mod Properties
-mod_version=1.8.1.4
+mod_version=1.8.1.1
 maven_group=io.github.flemmli97
 archives_base_name=flan
 


### PR DESCRIPTION
Adds support for [Bluemap](https://github.com/BlueMap-Minecraft/BlueMap) on Forge and Fabric. 

Bluemap does not persist markers itself and requires them all to be added when the API is loaded.

Bluemap also separates MarkerSets by world, which requires us to have access to MinecraftServer before registering the claim markers.