### PR TITLE
Fix disabled claiming spam

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
+++ b/common/src/main/java/io/github/flemmli97/flan/player/PlayerClaimData.java
@@ -329,11 +329,13 @@ public class PlayerClaimData implements IPlayerData {
             this.setEditingCorner(null);
             this.setEditClaim(null, 0);
             this.claimBlockMessage = false;
-        } else if (!this.claimBlockMessage && this.shouldDisplayClaimToolMessage()) {
+        } else if (!this.claimBlockMessage) {
             this.claimBlockMessage = true;
-            this.player.displayClientMessage(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
-                    this.getClaimBlocks(), this.getAdditionalClaims(), this.usedClaimBlocks(), this.remainingClaimBlocks()), ChatFormatting.GOLD), false);
-            this.addDisplayClaim(currentClaim, EnumDisplayType.MAIN, this.player.blockPosition().getY());
+            if (this.shouldDisplayClaimToolMessage()) {
+                this.player.displayClientMessage(PermHelper.simpleColoredText(String.format(ConfigHandler.langManager.get("claimBlocksFormat"),
+                        this.getClaimBlocks(), this.getAdditionalClaims(), this.usedClaimBlocks(), this.remainingClaimBlocks()), ChatFormatting.GOLD), false);
+                this.addDisplayClaim(currentClaim, EnumDisplayType.MAIN, this.player.blockPosition().getY());
+            }
         }
         this.actionCooldown--;
         if (--this.trappedTick >= 0) {


### PR DESCRIPTION
Fix #323. Moves the `shouldDisplayClaimToolMessage()` check to after `this.claimBlockMessage = true` so that it wont repeat the message again until after the tool has been cleared.