### PR TITLE
Update FlanProtectionProvider.java

### DIFF
--- a/fabric/src/main/java/io/github/flemmli97/flan/fabric/platform/integration/claiming/FlanProtectionProvider.java
+++ b/fabric/src/main/java/io/github/flemmli97/flan/fabric/platform/integration/claiming/FlanProtectionProvider.java
@@ -66,7 +66,7 @@ public class FlanProtectionProvider implements ProtectionProvider {
 
     @Override
     public boolean canBreakBlock(Level world, BlockPos pos, GameProfile profile, @Nullable Player player) {
-        if (!(world instanceof ServerLevel sl)) return false;
+        if (!(world instanceof ServerLevel sl)) return true;
 
         ServerPlayer sp = tryResolvePlayer(sl, profile);
 
@@ -75,7 +75,7 @@ public class FlanProtectionProvider implements ProtectionProvider {
 
     @Override
     public boolean canExplodeBlock(Level world, BlockPos pos, Explosion explosion, GameProfile profile, @Nullable Player player) {
-        if (!(world instanceof ServerLevel sl)) return false;
+        if (!(world instanceof ServerLevel sl)) return true;
 
         ServerPlayer sp = tryResolvePlayer(sl, profile);
 
@@ -84,7 +84,7 @@ public class FlanProtectionProvider implements ProtectionProvider {
 
     @Override
     public boolean canPlaceBlock(Level world, BlockPos pos, GameProfile profile, @Nullable Player player) {
-        if (!(world instanceof ServerLevel sl)) return false;
+        if (!(world instanceof ServerLevel sl)) return true;
 
         ServerPlayer sp = tryResolvePlayer(sl, profile);
 
@@ -93,7 +93,7 @@ public class FlanProtectionProvider implements ProtectionProvider {
 
     @Override
     public boolean canInteractBlock(Level world, BlockPos pos, GameProfile profile, @Nullable Player player) {
-        if (!(world instanceof ServerLevel sl)) return false;
+        if (!(world instanceof ServerLevel sl)) return true;
 
         ServerPlayer sp = tryResolvePlayer(sl, profile);
 
@@ -114,7 +114,7 @@ public class FlanProtectionProvider implements ProtectionProvider {
 
     @Override
     public boolean canInteractEntity(Level world, Entity entity, GameProfile profile, @Nullable Player player) {
-        if (!(world instanceof ServerLevel sl)) return false;
+        if (!(world instanceof ServerLevel sl)) return true;
 
         ServerPlayer sp = tryResolvePlayer(sl, profile);
 
@@ -132,7 +132,7 @@ public class FlanProtectionProvider implements ProtectionProvider {
 
     @Override
     public boolean canDamageEntity(Level world, Entity entity, GameProfile profile, @Nullable Player player) {
-        if (!(world instanceof ServerLevel sl)) return false;
+        if (!(world instanceof ServerLevel sl)) return true;
 
         ServerPlayer sp = tryResolvePlayer(sl, profile);
 


### PR DESCRIPTION
In a hypothetical scenario where Level is not ServerLevel, the smartest decision would be to return true and not false in these methods. It's a standard logic in ProtectionProvider.class:

(code from ProtectionProvider.class):
boolean canBreakBlock(...) {
   return !this.isProtected(...)
}

Reverted logic, as you can see

Even FTB is doing it like this:
https://github.com/FTBTeam/FTB-XMod-Compat/blob/main/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/commonprot/FTBChunksProtectionProvider.java#L142
https://github.com/FTBTeam/FTB-XMod-Compat/blob/main/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/commonprot/FTBChunksProtectionProvider.java#L135