### PR TITLE
Add command confirmation system for sensitive actions

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
@@ -54,6 +54,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.mrliam2614.flan.commands.CommandCallback;
+import net.mrliam2614.flan.commands.CommandConfirmation;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,6 +69,9 @@ import java.util.stream.Stream;
 public class CommandClaim {
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext buildContext, boolean dedicated) {
+        //MrLiam2614 - Register Command Confirmation
+        new CommandConfirmation();
+
         LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal("flan")
                 .then(Commands.literal("reload").requires(src -> PermissionNodeHandler.INSTANCE.perm(src, PermissionNodeHandler.cmdReload, true)).executes(CommandClaim::reloadConfig))
                 .then(Commands.literal("add").requires(src -> PermissionNodeHandler.INSTANCE.perm(src, PermissionNodeHandler.claimCreate))
@@ -198,7 +203,8 @@ public class CommandClaim {
                                                 .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.ENTITYATTACK))))
                                 .then(Commands.literal(CustomInteractListScreenHandler.Type.ENTITYUSE.commandKey)
                                         .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.ENTITY_TYPE)).suggests((src, b) -> CommandHelpers.claimEntryListSuggestion(src, b, CustomInteractListScreenHandler.Type.ENTITYUSE))
-                                                .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.ENTITYUSE)))))
+                                                .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.ENTITYUSE))))))
+                .then(Commands.literal("confirm").requires(src -> PermissionNodeHandler.INSTANCE.perm(src, PermissionNodeHandler.cmdConfirm)).executes(CommandClaim::confirmCommand)
                 );
         builder.then(Commands.literal("help").executes(ctx -> CommandHelp.helpMessage(ctx, 0, builder.getArguments()))
                 .then(Commands.argument("page", IntegerArgumentType.integer()).executes(ctx -> CommandHelp.helpMessage(ctx, builder.getArguments())))
@@ -581,15 +587,21 @@ public class CommandClaim {
     }
 
     private static int adminDelete(CommandContext<CommandSourceStack> context) {
-        CommandSourceStack src = context.getSource();
-        ClaimStorage storage = ClaimStorage.get(src.getLevel());
-        Claim claim = storage.getClaimAt(BlockPos.containing(src.getPosition()));
-        if (claim == null) {
-            src.sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("noClaim"), ChatFormatting.RED), false);
-            return 0;
-        }
-        storage.deleteClaim(claim, true, EnumEditMode.DEFAULT, src.getLevel());
-        src.sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("deleteClaim"), ChatFormatting.RED), true);
+        CommandConfirmation.INSTANCE.requestConfirmation(context, new CommandCallback() {
+            @Override
+            public int onConfirm(CommandContext<CommandSourceStack> context) {
+                CommandSourceStack src = context.getSource();
+                ClaimStorage storage = ClaimStorage.get(src.getLevel());
+                Claim claim = storage.getClaimAt(BlockPos.containing(src.getPosition()));
+                if (claim == null) {
+                    src.sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("noClaim"), ChatFormatting.RED), false);
+                    return 0;
+                }
+                storage.deleteClaim(claim, true, EnumEditMode.DEFAULT, src.getLevel());
+                src.sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("deleteClaim"), ChatFormatting.RED), true);
+                return Command.SINGLE_SUCCESS;
+            }
+        });
         return Command.SINGLE_SUCCESS;
     }
 
@@ -1067,5 +1079,12 @@ public class CommandClaim {
                 list.addAllowedItem(Either.left(entry));
         });
         return value.asPrintable();
+    }
+
+
+    /* Confirm Command by MrLiam2614 */
+    private static int confirmCommand(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        ServerPlayer player = context.getSource().getPlayerOrException();
+        return CommandConfirmation.INSTANCE.confirmCommand(context);
     }
 }

--- a/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
@@ -204,7 +204,7 @@ public class CommandClaim {
                                 .then(Commands.literal(CustomInteractListScreenHandler.Type.ENTITYUSE.commandKey)
                                         .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.ENTITY_TYPE)).suggests((src, b) -> CommandHelpers.claimEntryListSuggestion(src, b, CustomInteractListScreenHandler.Type.ENTITYUSE))
                                                 .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.ENTITYUSE))))))
-                .then(Commands.literal("confirm").requires(src -> PermissionNodeHandler.INSTANCE.perm(src, PermissionNodeHandler.cmdConfirm)).executes(CommandClaim::confirmCommand)
+                .then(Commands.literal("confirm").requires(src -> PermissionNodeHandler.INSTANCE.perm(src, PermissionNodeHandler.cmdConfirm, true)).executes(CommandClaim::confirmCommand)
                 );
         builder.then(Commands.literal("help").executes(ctx -> CommandHelp.helpMessage(ctx, 0, builder.getArguments()))
                 .then(Commands.argument("page", IntegerArgumentType.integer()).executes(ctx -> CommandHelp.helpMessage(ctx, builder.getArguments())))

--- a/common/src/main/java/io/github/flemmli97/flan/config/LangManager.java
+++ b/common/src/main/java/io/github/flemmli97/flan/config/LangManager.java
@@ -224,6 +224,8 @@ public class LangManager {
         this.defaultTranslation.put("removeIgnoreEntry", "Removed %1$s from the claims ignore list %2$s");
 
         this.defaultTranslation.put("wiki", "For more info check out the wiki:");
+        this.defaultTranslation.put("confirmMessage", "Run the command '/flan confirm' if you are sure you want to execute this command.");
+        this.defaultTranslation.put("confirmCancelled", "Your command has not been sent.");
 
         for (ClaimPermission perm : PermissionManager.INSTANCE.getAll()) {
             this.defaultTranslation.put(perm.translationKey(), this.capitalize(perm.getId().getPath()));
@@ -260,9 +262,7 @@ public class LangManager {
         this.defaultTranslationArray.put("command.listAdminClaims", new String[]{"listAdminClaim", "Lists all admin claims in the current world."});
         this.defaultTranslationArray.put("command.adminDelete", new String[]{"adminDelete [all <player>]", "Force deletes the current claim or deletes all claims from the specified player."});
         this.defaultTranslationArray.put("command.giveClaimBlocks", new String[]{"giveClaimBlocks <amount>", "Gives a player additional claim blocks."});
-
-        this.defaultTranslation.put("command.confirmation.confirmMessage", "Run the command '/flan confirm' if you are sure you want to execute this command.");
-        this.defaultTranslation.put("command.confirmation.cancelled", "Your command has not been sent.");
+        this.defaultTranslationArray.put("command.confirm", new String[]{"confirm", "Confirm a command to send it."});
     }
 
     private String capitalize(String s) {

--- a/common/src/main/java/io/github/flemmli97/flan/config/LangManager.java
+++ b/common/src/main/java/io/github/flemmli97/flan/config/LangManager.java
@@ -260,6 +260,9 @@ public class LangManager {
         this.defaultTranslationArray.put("command.listAdminClaims", new String[]{"listAdminClaim", "Lists all admin claims in the current world."});
         this.defaultTranslationArray.put("command.adminDelete", new String[]{"adminDelete [all <player>]", "Force deletes the current claim or deletes all claims from the specified player."});
         this.defaultTranslationArray.put("command.giveClaimBlocks", new String[]{"giveClaimBlocks <amount>", "Gives a player additional claim blocks."});
+
+        this.defaultTranslation.put("command.confirmation.confirmMessage", "Run the command '/flan confirm' if you are sure you want to execute this command.");
+        this.defaultTranslation.put("command.confirmation.cancelled", "Your command has not been sent.");
     }
 
     private String capitalize(String s) {

--- a/common/src/main/java/io/github/flemmli97/flan/platform/integration/permissions/PermissionNodeHandler.java
+++ b/common/src/main/java/io/github/flemmli97/flan/platform/integration/permissions/PermissionNodeHandler.java
@@ -55,6 +55,8 @@ public interface PermissionNodeHandler {
     String permClaimBlocksCap = "flan.claim.blocks.cap";
     String permClaimBlocksBonus = "flan.claim.blocks.bonus";
 
+    String cmdConfirm = "flan.command.confirm";
+
     PermissionNodeHandler INSTANCE = Flan.getPlatformInstance(PermissionNodeHandler.class,
             "io.github.flemmli97.flan.fabric.platform.integration.permissions.PermissionNodeHandlerImpl",
             "io.github.flemmli97.flan.forge.platform.integration.permissions.PermissionNodeHandlerImpl");

--- a/common/src/main/java/net/mrliam2614/flan/commands/CommandCallback.java
+++ b/common/src/main/java/net/mrliam2614/flan/commands/CommandCallback.java
@@ -1,0 +1,44 @@
+package net.mrliam2614.flan.commands;
+
+import com.mojang.brigadier.context.CommandContext;
+import io.github.flemmli97.flan.claim.PermHelper;
+import io.github.flemmli97.flan.config.ConfigHandler;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+
+/**
+ * Interface representing a callback mechanism for commands that require user confirmation before proceeding.
+ * <p>
+ * Provides a method to handle the confirmation action (`onConfirm`) and a default implementation to handle the
+ * denial or cancellation of the operation (`onDeny`).
+ * <p>
+ * If the command is called not a player (console) is automatically called the (`onConfirm`)
+ */
+public interface CommandCallback {
+
+    /**
+     * Called when the command is confirmed by the user.
+     *
+     * @param context The {@link CommandContext} for the current command execution,
+     *                containing information about the source and arguments of the command.
+     * @return An integer value typically used to indicate the result of command execution.
+     */
+    int onConfirm(CommandContext<CommandSourceStack> context);
+
+    /**
+     * Called when the command is denied or canceled by the user.
+     * This method provides a default implementation that sends a cancellation message
+     * to the command source using the configured language manager and displays it in red formatting.
+     *
+     * @param context The {@link CommandContext} for the current command execution,
+     *                containing information about the source and arguments of the command.
+     */
+    default void onDeny(CommandContext<CommandSourceStack> context) {
+        context.getSource().sendSuccess(() ->
+                PermHelper.simpleColoredText(
+                        ConfigHandler.LANG_MANAGER.get("command.confirmation.cancelled"),
+                        ChatFormatting.RED
+                ), true
+        );
+    }
+}

--- a/common/src/main/java/net/mrliam2614/flan/commands/CommandCallback.java
+++ b/common/src/main/java/net/mrliam2614/flan/commands/CommandCallback.java
@@ -36,7 +36,7 @@ public interface CommandCallback {
     default void onDeny(CommandContext<CommandSourceStack> context) {
         context.getSource().sendSuccess(() ->
                 PermHelper.simpleColoredText(
-                        ConfigHandler.LANG_MANAGER.get("command.confirmation.cancelled"),
+                        ConfigHandler.LANG_MANAGER.get("confirmCancelled"),
                         ChatFormatting.RED
                 ), true
         );

--- a/common/src/main/java/net/mrliam2614/flan/commands/CommandConfirmation.java
+++ b/common/src/main/java/net/mrliam2614/flan/commands/CommandConfirmation.java
@@ -37,7 +37,7 @@ public class CommandConfirmation {
         }
         UUID uuid = context.getSource().getPlayer().getUUID();
         awaitingConfirmation.put(uuid, commandCallback);
-        context.getSource().sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("command.confirmation.confirmMessage"), ChatFormatting.AQUA), true);
+        context.getSource().sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("confirmMessage"), ChatFormatting.AQUA), true);
     }
 
     /**

--- a/common/src/main/java/net/mrliam2614/flan/commands/CommandConfirmation.java
+++ b/common/src/main/java/net/mrliam2614/flan/commands/CommandConfirmation.java
@@ -1,0 +1,65 @@
+package net.mrliam2614.flan.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import io.github.flemmli97.flan.claim.PermHelper;
+import io.github.flemmli97.flan.config.ConfigHandler;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+/**
+ * The {@code CommandConfirmation} class manages command operations that require user confirmation before being executed.
+ * It maintains a registry of commands awaiting confirmation and provides mechanisms for requesting and confirming such commands.
+ */
+public class CommandConfirmation {
+    public static CommandConfirmation INSTANCE;
+    private HashMap<UUID, CommandCallback> awaitingConfirmation;
+
+    public CommandConfirmation() {
+        INSTANCE = this;
+        awaitingConfirmation = new HashMap<>();
+    }
+
+    /**
+     * Requests confirmation from a player for a specific command operation. If the player is active, it adds the command
+     * callback to a list awaiting confirmation and sends a confirmation message to the player.
+     *
+     * @param context The {@link CommandContext} containing information about the command execution,
+     *                including the source of the command (player or console).
+     * @param commandCallback The {@link CommandCallback} instance representing the action to be executed upon confirmation.
+     */
+    public void requestConfirmation(CommandContext<CommandSourceStack> context, CommandCallback commandCallback) {
+        if(context.getSource().getPlayer() == null){
+            return;
+        }
+        UUID uuid = context.getSource().getPlayer().getUUID();
+        awaitingConfirmation.put(uuid, commandCallback);
+        context.getSource().sendSuccess(() -> PermHelper.simpleColoredText(ConfigHandler.LANG_MANAGER.get("command.confirmation.confirmMessage"), ChatFormatting.AQUA), true);
+    }
+
+    /**
+     * Processes a confirmation action for a command that is awaiting user confirmation.
+     * If the command source is eligible (e.g., a player), it retrieves and executes the
+     * associated {@link CommandCallback} if present.
+     *
+     * @param context The {@link CommandContext} containing information about the command execution,
+     *                including the source of the command (e.g., player or console).
+     * @return An integer value indicating the outcome of the confirmed command execution.
+     *         Returns 0 if no confirmation action was processed, such as when the source
+     *         is not a player or no command callback is awaiting confirmation.
+     */
+    public int confirmCommand(CommandContext<CommandSourceStack> context){
+        if(context.getSource().getPlayer() == null){
+            return 0;
+        }
+        UUID uuid = context.getSource().getPlayer().getUUID();
+        CommandCallback commandCallback = awaitingConfirmation.remove(uuid);
+        if(commandCallback == null){
+            return 0;
+        }
+        return commandCallback.onConfirm(context);
+    }
+}

--- a/common/src/main/resources/data/flan/lang/it_it.json
+++ b/common/src/main/resources/data/flan/lang/it_it.json
@@ -151,6 +151,8 @@
   "setLeaveMessage": "Imposta il titolo di uscita a %1$s",
   "setLeaveSubMessage": "Imposta il sottotitolo di uscita a %1$s",
   "wiki": "Per più informazioni controlla la wiki:",
+  "confirmMessage": "Run the command '/flan confirm' if you are sure you want to execute this command.",
+  "confirmCancelled": "Your command has not been sent.",
   "command.help": [
     "help <pagina> | (cmd <comando>)",
     "Mostra tutti i comandi o le info disponibili per il comandi fornito."
@@ -269,7 +271,5 @@
   "command.giveClaimBlocks": [
     "giveClaimBlocks <quantità>",
     "Fornisce a un giocatore ulteriori blocchi di claim."
-  ],
-  "command.confirmation.confirmMessage": "Run the command '/flan confirm' if you are sure you want to execute this command.",
-  "command.confirmation.cancelled": "Your command has not been sent."
+  ]
 }

--- a/common/src/main/resources/data/flan/lang/it_it.json
+++ b/common/src/main/resources/data/flan/lang/it_it.json
@@ -269,5 +269,7 @@
   "command.giveClaimBlocks": [
     "giveClaimBlocks <quantità>",
     "Fornisce a un giocatore ulteriori blocchi di claim."
-  ]
+  ],
+  "command.confirmation.confirmMessage": "Run the command '/flan confirm' if you are sure you want to execute this command.",
+  "command.confirmation.cancelled": "Your command has not been sent."
 }


### PR DESCRIPTION
Introduced a confirmation mechanism requiring users to explicitly confirm certain commands, preventing unintended actions. This includes a new `/flan confirm` command, callback handling, and supporting translations for confirmation and cancellation messages. Confirmation for now added only to adminDelete

Improves the current system where you have to send the command twice (not replaced in the code, so the Dev can evaluate what to do)