### PR TITLE
Option to whitelist blocks for place block event

### DIFF
--- a/common/src/generated/resources/data/flan/lang/en_us.json
+++ b/common/src/generated/resources/data/flan/lang/en_us.json
@@ -128,6 +128,7 @@
   "flan.screenDelete": "Use \"$empty\" to delete the message",
   "flan.screenMenuItemUse": "Allowed item use",
   "flan.screenMenuBlockBreak": "Allowed block break",
+  "flan.screenMenuBlockPlace": "Allowed block place",
   "flan.screenMenuBlockUse": "Allowed block use",
   "flan.screenMenuEntityAttack": "Allowed entities to attack",
   "flan.screenMenuEntityUse": "Allowed entity interactions",

--- a/common/src/generated/resources/data/flan/lang/en_us.json
+++ b/common/src/generated/resources/data/flan/lang/en_us.json
@@ -128,7 +128,6 @@
   "flan.screenDelete": "Use \"$empty\" to delete the message",
   "flan.screenMenuItemUse": "Allowed item use",
   "flan.screenMenuBlockBreak": "Allowed block break",
-  "flan.screenMenuBlockPlace": "Allowed block place",
   "flan.screenMenuBlockUse": "Allowed block use",
   "flan.screenMenuEntityAttack": "Allowed entities to attack",
   "flan.screenMenuEntityUse": "Allowed entity interactions",

--- a/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
@@ -90,6 +90,7 @@ public class Claim implements IPermissionContainer {
 
     public final AllowedRegistryList<Item> allowedItems = AllowedRegistryList.ofItemLike(BuiltInRegistries.ITEM, this);
     public final AllowedRegistryList<Block> allowedUseBlocks = AllowedRegistryList.ofItemLike(BuiltInRegistries.BLOCK, this);
+    public final AllowedRegistryList<Block> allowedPlaceBlocks = AllowedRegistryList.ofItemLike(BuiltInRegistries.BLOCK, this);
     public final AllowedRegistryList<Block> allowedBreakBlocks = AllowedRegistryList.ofItemLike(BuiltInRegistries.BLOCK, this);
     public final AllowedRegistryList<EntityType<?>> allowedEntityAttack = new AllowedRegistryList<>(BuiltInRegistries.ENTITY_TYPE, this, AllowedRegistryList.ENTITY_AS_ITEM);
     public final AllowedRegistryList<EntityType<?>> allowedEntityUse = new AllowedRegistryList<>(BuiltInRegistries.ENTITY_TYPE, this, AllowedRegistryList.ENTITY_AS_ITEM);
@@ -705,6 +706,10 @@ public class Claim implements IPermissionContainer {
         return this.allowedBreakBlocks.matches(state::is, state::is);
     }
 
+    public boolean canPlaceBlockItem(BlockState state) {
+        return this.allowedPlaceBlocks.matches(state::is, state::is);
+    }
+
     public boolean canAttackEntity(Entity entity) {
         return this.allowedEntityAttack.matches(type -> entity.getType() == type, tag -> entity.getType().is(tag));
     }
@@ -774,6 +779,7 @@ public class Claim implements IPermissionContainer {
             this.allowedItems.read(ConfigHandler.arryFromJson(obj, "AllowedItems"));
             this.allowedUseBlocks.read(ConfigHandler.arryFromJson(obj, "AllowedUseBlocks"));
             this.allowedBreakBlocks.read(ConfigHandler.arryFromJson(obj, "AllowedBreakBlocks"));
+            this.allowedPlaceBlocks.read(ConfigHandler.arryFromJson(obj, "AllowedPlaceBlocks"));
             this.allowedEntityAttack.read(ConfigHandler.arryFromJson(obj, "AllowedEntityAttack"));
             this.allowedEntityUse.read(ConfigHandler.arryFromJson(obj, "AllowedEntityUse"));
             this.globalPerm.clear();
@@ -842,6 +848,7 @@ public class Claim implements IPermissionContainer {
         obj.add("AllowedItems", this.allowedItems.save());
         obj.add("AllowedUseBlocks", this.allowedUseBlocks.save());
         obj.add("AllowedBreakBlocks", this.allowedBreakBlocks.save());
+        obj.add("AllowedPlaceBlocks", this.allowedPlaceBlocks.save());
         obj.add("AllowedEntityAttack", this.allowedEntityAttack.save());
         obj.add("AllowedEntityUse", this.allowedEntityUse.save());
         if (!this.globalPerm.isEmpty()) {

--- a/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/commands/CommandClaim.java
@@ -176,6 +176,9 @@ public class CommandClaim {
                                 .then(Commands.literal(CustomInteractListScreenHandler.Type.BLOCKBREAK.commandKey)
                                         .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.BLOCK))
                                                 .executes(src -> CommandClaim.addClaimListEntries(src, CustomInteractListScreenHandler.Type.BLOCKBREAK))))
+                                .then(Commands.literal(CustomInteractListScreenHandler.Type.BLOCKPLACE.commandKey)
+                                        .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.BLOCK))
+                                                .executes(src -> CommandClaim.addClaimListEntries(src, CustomInteractListScreenHandler.Type.BLOCKPLACE))))
                                 .then(Commands.literal(CustomInteractListScreenHandler.Type.BLOCKUSE.commandKey)
                                         .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.BLOCK))
                                                 .executes(src -> CommandClaim.addClaimListEntries(src, CustomInteractListScreenHandler.Type.BLOCKUSE))))
@@ -192,6 +195,9 @@ public class CommandClaim {
                                 .then(Commands.literal(CustomInteractListScreenHandler.Type.BLOCKBREAK.commandKey)
                                         .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.BLOCK)).suggests((src, b) -> CommandHelpers.claimEntryListSuggestion(src, b, CustomInteractListScreenHandler.Type.BLOCKBREAK))
                                                 .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.BLOCKBREAK))))
+                                .then(Commands.literal(CustomInteractListScreenHandler.Type.BLOCKPLACE.commandKey)
+                                        .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.BLOCK)).suggests((src, b) -> CommandHelpers.claimEntryListSuggestion(src, b, CustomInteractListScreenHandler.Type.BLOCKPLACE))
+                                                .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.BLOCKPLACE))))
                                 .then(Commands.literal(CustomInteractListScreenHandler.Type.BLOCKUSE.commandKey)
                                         .then(Commands.argument("entry", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.BLOCK)).suggests((src, b) -> CommandHelpers.claimEntryListSuggestion(src, b, CustomInteractListScreenHandler.Type.BLOCKUSE))
                                                 .executes(src -> CommandClaim.removeClaimListEntries(src, CustomInteractListScreenHandler.Type.BLOCKUSE))))
@@ -1033,6 +1039,7 @@ public class CommandClaim {
         String result = switch (type) {
             case ITEM -> addClaimListEntry(context, BuiltInRegistries.ITEM, claim.allowedItems);
             case BLOCKBREAK -> addClaimListEntry(context, BuiltInRegistries.BLOCK, claim.allowedBreakBlocks);
+            case BLOCKPLACE -> addClaimListEntry(context, BuiltInRegistries.BLOCK, claim.allowedPlaceBlocks);
             case BLOCKUSE -> addClaimListEntry(context, BuiltInRegistries.BLOCK, claim.allowedUseBlocks);
             case ENTITYATTACK -> addClaimListEntry(context, BuiltInRegistries.ENTITY_TYPE, claim.allowedEntityAttack);
             case ENTITYUSE -> addClaimListEntry(context, BuiltInRegistries.ENTITY_TYPE, claim.allowedEntityUse);
@@ -1055,6 +1062,7 @@ public class CommandClaim {
         switch (type) {
             case ITEM -> claim.allowedItems.removeAllowedItem(value);
             case BLOCKBREAK -> claim.allowedBreakBlocks.removeAllowedItem(value);
+            case BLOCKPLACE -> claim.allowedPlaceBlocks.removeAllowedItem(value);
             case BLOCKUSE -> claim.allowedUseBlocks.removeAllowedItem(value);
             case ENTITYATTACK -> claim.allowedEntityAttack.removeAllowedItem(value);
             case ENTITYUSE -> claim.allowedEntityUse.removeAllowedItem(value);

--- a/common/src/main/java/io/github/flemmli97/flan/commands/CommandHelpers.java
+++ b/common/src/main/java/io/github/flemmli97/flan/commands/CommandHelpers.java
@@ -125,6 +125,7 @@ public class CommandHelpers {
             switch (type) {
                 case ITEM -> list = claim.allowedItems.asString();
                 case BLOCKBREAK -> list = claim.allowedBreakBlocks.asString();
+                case BLOCKPLACE -> list = claim.allowedPlaceBlocks.asString();
                 case BLOCKUSE -> list = claim.allowedUseBlocks.asString();
                 case ENTITYATTACK -> list = claim.allowedEntityAttack.asString();
                 case ENTITYUSE -> list = claim.allowedEntityUse.asString();

--- a/common/src/main/java/io/github/flemmli97/flan/event/ItemInteractEvents.java
+++ b/common/src/main/java/io/github/flemmli97/flan/event/ItemInteractEvents.java
@@ -128,8 +128,8 @@ public class ItemInteractEvents {
                 return InteractionResult.FAIL;
             }
         }
-        if (claim.canInteract(player, BuiltinPermission.PLACE, placePos, false)) {
-            if (column != null && stack.getItem() instanceof BlockItem) {
+        if (canPlaceThisBlock(stack, claim) || claim.canInteract(player, BuiltinPermission.PLACE, placePos, false)) {
+            if (column != null) {
                 column.extendDownwards(placePos);
             }
             return InteractionResult.PASS;
@@ -140,6 +140,10 @@ public class ItemInteractEvents {
         PlayerClaimData.get(player).addDisplayClaim(claim, EnumDisplayType.MAIN, player.blockPosition().getY());
         updateHeldItem(player);
         return InteractionResult.FAIL;
+    }
+
+    private static boolean canPlaceThisBlock(ItemStack stack, IPermissionContainer claim) {
+        return claim instanceof Claim real && stack.getItem() instanceof BlockItem block && real.canPlaceBlockItem(block.getBlock().defaultBlockState());
     }
 
     /**

--- a/common/src/main/java/io/github/flemmli97/flan/gui/ClaimMenuScreenHandler.java
+++ b/common/src/main/java/io/github/flemmli97/flan/gui/ClaimMenuScreenHandler.java
@@ -23,7 +23,7 @@ import net.minecraft.world.item.alchemy.Potions;
 public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
 
     private ClaimMenuScreenHandler(int syncId, Inventory playerInventory, Claim claim) {
-        super(syncId, playerInventory, 2, claim);
+        super(syncId, playerInventory, 3, claim);
     }
 
     public static void openClaimMenu(ServerPlayer player, Claim claim) {
@@ -43,7 +43,7 @@ public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
 
     @Override
     protected void fillInventoryWith() {
-        for (int i = 0; i < 18; i++) {
+        for (int i = 0; i < 27; i++) {
             switch (i) {
                 case 0 -> {
                     ItemStack close = new ItemStack(Items.TNT);
@@ -108,20 +108,27 @@ public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
                     this.slots.get(i).set(stack);
                 }
                 case 13 -> {
+                    ItemStack stack = new ItemStack(Items.DIAMOND_SHOVEL);
+                    stack.setHoverName(ServerScreenHelper.coloredGuiText(CustomInteractListScreenHandler.Type.BLOCKPLACE.translationKey, ChatFormatting.GOLD));
+                    if (!this.hasPerm(this.data, this.player, BuiltinPermission.EDITCLAIM))
+                        ServerScreenHelper.addLore(stack, ServerScreenHelper.coloredGuiText("flan.screenNoPerm", ChatFormatting.DARK_RED));
+                    this.slots.get(i).set(stack);
+                }
+                case 14 -> {
                     ItemStack stack = new ItemStack(Items.RED_BANNER);
                     stack.setHoverName(ServerScreenHelper.coloredGuiText(CustomInteractListScreenHandler.Type.BLOCKUSE.translationKey, ChatFormatting.GOLD));
                     if (!this.hasPerm(this.data, this.player, BuiltinPermission.EDITCLAIM))
                         ServerScreenHelper.addLore(stack, ServerScreenHelper.coloredGuiText("flan.screenNoPerm", ChatFormatting.DARK_RED));
                     this.slots.get(i).set(stack);
                 }
-                case 14 -> {
+                case 15 -> {
                     ItemStack stack = new ItemStack(Items.DIAMOND_SWORD);
                     stack.setHoverName(ServerScreenHelper.coloredGuiText(CustomInteractListScreenHandler.Type.ENTITYATTACK.translationKey, ChatFormatting.GOLD));
                     if (!this.hasPerm(this.data, this.player, BuiltinPermission.EDITCLAIM))
                         ServerScreenHelper.addLore(stack, ServerScreenHelper.coloredGuiText("flan.screenNoPerm", ChatFormatting.DARK_RED));
                     this.slots.get(i).set(stack);
                 }
-                case 15 -> {
+                case 20 -> {
                     ItemStack stack = new ItemStack(Items.SHEARS);
                     stack.setHoverName(ServerScreenHelper.coloredGuiText(CustomInteractListScreenHandler.Type.ENTITYUSE.translationKey, ChatFormatting.GOLD));
                     if (!this.hasPerm(this.data, this.player, BuiltinPermission.EDITCLAIM))
@@ -135,7 +142,7 @@ public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
 
     @Override
     protected boolean isRightSlot(int slot) {
-        return slot == 0 || slot == 2 || slot == 3 || slot == 4 || slot == 5 || slot == 6 || slot == 8 || (slot >= 11 && slot <= 15);
+        return slot == 0 || slot == 2 || slot == 3 || slot == 4 || slot == 5 || slot == 6 || slot == 8 || (slot >= 11 && slot <= 15) || slot == 20;
     }
 
     @Override
@@ -223,7 +230,7 @@ public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
             case 13:
                 if (this.hasPerm(this.data, player, BuiltinPermission.EDITPERMS)) {
                     player.closeContainer();
-                    player.getServer().execute(() -> CustomInteractListScreenHandler.openMenu(player, CustomInteractListScreenHandler.Type.BLOCKUSE, this.data));
+                    player.getServer().execute(() -> CustomInteractListScreenHandler.openMenu(player, CustomInteractListScreenHandler.Type.BLOCKPLACE, this.data));
                     ServerScreenHelper.playSongToPlayer(player, SoundEvents.UI_BUTTON_CLICK, 1, 1f);
                 } else
                     ServerScreenHelper.playSongToPlayer(player, SoundEvents.VILLAGER_NO, 1, 1f);
@@ -231,12 +238,20 @@ public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
             case 14:
                 if (this.hasPerm(this.data, player, BuiltinPermission.EDITPERMS)) {
                     player.closeContainer();
-                    player.getServer().execute(() -> CustomInteractListScreenHandler.openMenu(player, CustomInteractListScreenHandler.Type.ENTITYATTACK, this.data));
+                    player.getServer().execute(() -> CustomInteractListScreenHandler.openMenu(player, CustomInteractListScreenHandler.Type.BLOCKUSE, this.data));
                     ServerScreenHelper.playSongToPlayer(player, SoundEvents.UI_BUTTON_CLICK, 1, 1f);
                 } else
                     ServerScreenHelper.playSongToPlayer(player, SoundEvents.VILLAGER_NO, 1, 1f);
                 break;
             case 15:
+                if (this.hasPerm(this.data, player, BuiltinPermission.EDITPERMS)) {
+                    player.closeContainer();
+                    player.getServer().execute(() -> CustomInteractListScreenHandler.openMenu(player, CustomInteractListScreenHandler.Type.ENTITYATTACK, this.data));
+                    ServerScreenHelper.playSongToPlayer(player, SoundEvents.UI_BUTTON_CLICK, 1, 1f);
+                } else
+                    ServerScreenHelper.playSongToPlayer(player, SoundEvents.VILLAGER_NO, 1, 1f);
+                break;
+            case 20:
                 if (this.hasPerm(this.data, player, BuiltinPermission.EDITPERMS)) {
                     player.closeContainer();
                     player.getServer().execute(() -> CustomInteractListScreenHandler.openMenu(player, CustomInteractListScreenHandler.Type.ENTITYUSE, this.data));

--- a/common/src/main/java/io/github/flemmli97/flan/gui/CustomInteractListScreenHandler.java
+++ b/common/src/main/java/io/github/flemmli97/flan/gui/CustomInteractListScreenHandler.java
@@ -69,6 +69,7 @@ public class CustomInteractListScreenHandler extends PagedServerOnlyScreenHandle
                 List<ItemStack> stacks = switch (this.data.type) {
                     case ITEM -> this.data.claim.allowedItems.asStacks();
                     case BLOCKBREAK -> this.data.claim.allowedBreakBlocks.asStacks();
+                    case BLOCKPLACE -> this.data.claim.allowedPlaceBlocks.asStacks();
                     case BLOCKUSE -> this.data.claim.allowedUseBlocks.asStacks();
                     case ENTITYATTACK -> this.data.claim.allowedEntityAttack.asStacks();
                     case ENTITYUSE -> this.data.claim.allowedEntityUse.asStacks();
@@ -118,6 +119,15 @@ public class CustomInteractListScreenHandler extends PagedServerOnlyScreenHandle
                             Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(s));
                             if (block != Blocks.AIR)
                                 this.data.claim.allowedBreakBlocks.addAllowedItem(Either.left(block));
+                        }
+                    }
+                    case BLOCKPLACE -> {
+                        if (s.startsWith("#"))
+                            this.data.claim.allowedPlaceBlocks.addAllowedItem(Either.right(TagKey.create(BuiltInRegistries.BLOCK.key(), new ResourceLocation(s.substring(1)))));
+                        else {
+                            Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(s));
+                            if (block != Blocks.AIR)
+                                this.data.claim.allowedPlaceBlocks.addAllowedItem(Either.left(block));
                         }
                     }
                     case BLOCKUSE -> {
@@ -175,6 +185,7 @@ public class CustomInteractListScreenHandler extends PagedServerOnlyScreenHandle
                 switch (this.data.type) {
                     case ITEM -> this.data.claim.allowedItems.removeAllowedItem(idx);
                     case BLOCKBREAK -> this.data.claim.allowedBreakBlocks.removeAllowedItem(idx);
+                    case BLOCKPLACE -> this.data.claim.allowedPlaceBlocks.removeAllowedItem(idx);
                     case BLOCKUSE -> this.data.claim.allowedUseBlocks.removeAllowedItem(idx);
                 }
                 slot.set(ItemStack.EMPTY);
@@ -189,6 +200,7 @@ public class CustomInteractListScreenHandler extends PagedServerOnlyScreenHandle
         int size = switch (this.data.type) {
             case ITEM -> this.data.claim.allowedItems.size();
             case BLOCKBREAK -> this.data.claim.allowedBreakBlocks.size();
+            case BLOCKPLACE -> this.data.claim.allowedPlaceBlocks.size();
             case BLOCKUSE -> this.data.claim.allowedUseBlocks.size();
             case ENTITYATTACK -> this.data.claim.allowedEntityAttack.size();
             case ENTITYUSE -> this.data.claim.allowedEntityUse.size();
@@ -203,6 +215,7 @@ public class CustomInteractListScreenHandler extends PagedServerOnlyScreenHandle
     public enum Type {
         ITEM("flan.screenMenuItemUse", "item"),
         BLOCKBREAK("flan.screenMenuBlockBreak", "block_break"),
+        BLOCKPLACE("flan.screenMenuBlockPlace", "block_place"),
         BLOCKUSE("flan.screenMenuBlockUse", "block_use"),
         ENTITYATTACK("flan.screenMenuEntityAttack", "entity_attack"),
         ENTITYUSE("flan.screenMenuEntityUse", "entity_use");

--- a/common/src/main/resources/data/flan/lang/es_mx.json
+++ b/common/src/main/resources/data/flan/lang/es_mx.json
@@ -130,6 +130,7 @@
   "flan.screenDelete": "Usa \"$empty\" para eliminar el mensaje",
   "flan.screenMenuItemUse": "Uso de ítems permitido",
   "flan.screenMenuBlockBreak": "Rompimiento de bloques permitido",
+  "flan.screenMenuBlockPlace": "Colocación de bloques permitida",
   "flan.screenMenuBlockUse": "Uso de bloques permitido",
   "flan.screenMenuEntityAttack": "Entidades permitidas para atacar",
   "flan.screenMenuEntityUse": "Interacciones con entidades permitidas",

--- a/common/src/main/resources/data/flan/lang/zh_cn.json
+++ b/common/src/main/resources/data/flan/lang/zh_cn.json
@@ -125,6 +125,7 @@
   "flan.screenDelete": "使用 \"$empty\" 删除消息",
   "flan.screenMenuItemUse": "使用出租物品",
   "flan.screenMenuBlockBreak": "允许破坏方块",
+  "flan.screenMenuBlockPlace": "允许放置方块",
   "flan.screenMenuBlockUse": "允许使用方块",
   "flan.screenMenuEntityAttack": "允许攻击实体",
   "flan.screenMenuEntityUse": "允许与实体互动",

--- a/common/src/main/resources/data/flan/lang/zh_tw.json
+++ b/common/src/main/resources/data/flan/lang/zh_tw.json
@@ -127,6 +127,7 @@
   "flan.screenDelete": "使用 \"$empty\" 刪除訊息",
   "flan.screenMenuItemUse": "允許使用物品",
   "flan.screenMenuBlockBreak": "允許破壞方塊",
+  "flan.screenMenuBlockPlace": "允許放置方塊"
   "flan.screenMenuBlockUse": "允許使用方塊",
   "flan.screenMenuEntityAttack": "允許攻擊實體",
   "flan.screenMenuEntityUse": "允許與實體互動",

--- a/forge/src/main/java/io/github/flemmli97/flan/data/ENLangGen.java
+++ b/forge/src/main/java/io/github/flemmli97/flan/data/ENLangGen.java
@@ -168,6 +168,7 @@ public class ENLangGen extends ServerLangGen {
         this.add("flan.screenDelete", "Use \"$empty\" to delete the message");
         this.add(CustomInteractListScreenHandler.Type.ITEM.translationKey, "Allowed item use");
         this.add(CustomInteractListScreenHandler.Type.BLOCKBREAK.translationKey, "Allowed block break");
+        this.add(CustomInteractListScreenHandler.Type.BLOCKPLACE.translationKey, "Allowed block place");
         this.add(CustomInteractListScreenHandler.Type.BLOCKUSE.translationKey, "Allowed block use");
         this.add(CustomInteractListScreenHandler.Type.ENTITYATTACK.translationKey, "Allowed entities to attack");
         this.add(CustomInteractListScreenHandler.Type.ENTITYUSE.translationKey, "Allowed entity interactions");

--- a/forge/src/main/java/io/github/flemmli97/flan/forge/forgeevent/BlockInteractEventsForge.java
+++ b/forge/src/main/java/io/github/flemmli97/flan/forge/forgeevent/BlockInteractEventsForge.java
@@ -3,6 +3,7 @@ package io.github.flemmli97.flan.forge.forgeevent;
 import io.github.flemmli97.flan.api.data.IPermissionContainer;
 import io.github.flemmli97.flan.api.permission.BuiltinPermission;
 import io.github.flemmli97.flan.api.permission.InteractionOverrideManager;
+import io.github.flemmli97.flan.claim.Claim;
 import io.github.flemmli97.flan.claim.ClaimStorage;
 import io.github.flemmli97.flan.claim.ClaimUtils;
 import io.github.flemmli97.flan.event.BlockInteractEvents;
@@ -74,6 +75,8 @@ public class BlockInteractEventsForge {
         ClaimStorage storage = ClaimStorage.get(player.serverLevel());
         IPermissionContainer claim = storage.getForPermissionCheck(placePos);
         if (claim == null)
+            return false;
+        if (claim instanceof Claim real && real.canPlaceBlockItem(placedBlock))
             return false;
         ResourceLocation perm = InteractionOverrideManager.INSTANCE.getBlockInteract(placedBlock.getBlock());
         if (perm != null) {


### PR DESCRIPTION
Mostly, need this PR to make this mod work on claims, becuase it does destroy-use-place chain of action to harvest crops in one press of RMB and Flan doesn't have option to whitelist blocks for "place" event  https://www.curseforge.com/minecraft/mc-mods/rightclickharvest 