### PR TITLE
Make flan respect its own global permissions. Issues: #415 #413

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
@@ -49,16 +49,7 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 public class Claim implements IPermissionContainer {
 
@@ -302,6 +293,15 @@ public class Claim implements IPermissionContainer {
         return this.removed;
     }
 
+    /**
+     * Check if a player in a certain position owns a defined permission.
+     *
+     * @param player  The player doing the action. Can be null
+     * @param perm    Permission that is going to be checked
+     * @param pos     Block position of said player
+     * @param message Should it send a message to the player that they do not have that permission.
+     * @return Does the player have that permission. TRUE if yes, FALSE if no.
+     */
     @Override
     public boolean canInteract(ServerPlayer player, ResourceLocation perm, BlockPos pos, boolean message) {
         boolean realPlayer = player != null && player.getClass().equals(ServerPlayer.class);
@@ -322,8 +322,10 @@ public class Claim implements IPermissionContainer {
         if (!this.isAdminClaim()) {
             Config.GlobalType global = ConfigHandler.CONFIG.getGlobal(this.level, perm);
             if (!global.canModify()) {
-                if (global.getValue() || (player != null && this.playerBypassesPermission(player, perm)))
+
+                if (global.getValue() || (player != null && this.playerBypassesPermission(player, perm))) {
                     return true;
+                }
                 if (message)
                     player.displayClientMessage(ClaimUtils.translatedText("flan.noPermissionSimple", ChatFormatting.DARK_RED), true);
                 if (perm.equals(BuiltinPermission.FAKEPLAYER))
@@ -377,14 +379,29 @@ public class Claim implements IPermissionContainer {
         return false;
     }
 
+    /**
+     * Can a player ignore a specified permission.
+     *
+     * @param player Player that is going to be checked.
+     * @param perm   Permission that is going to be checked.
+     * @return TRUE if the player can ignore that permission, FALSE if otherwise
+     */
     private boolean playerBypassesPermission(ServerPlayer player, ResourceLocation perm) {
         if (player == null)
             return true;
         ClaimPermission permission = PermissionManager.getInstance().get(perm);
-        if (permission != null && permission.requireExplicitSet)
+        if (permission == null)
+            return false; //Extracted this so that we don't need to check for null twice. -lukeonuke 09/09/2025
+
+        //Nobody bypasses unmodifiable (ALLTRUE/ALLFALSE) global permissions. #415
+        Config.GlobalType globalType = ConfigHandler.CONFIG.getGlobal(player.level(), perm);
+        if (!globalType.canModify()) return false;
+
+        if (permission.requireExplicitSet)
             return false;
-        if (player.getUUID().equals(this.owner))
+        if (player.getUUID().equals(this.owner)) {
             return true;
+        }
         if (PlayerClaimData.get(player).isAdminIgnoreClaim())
             return !this.isAdminClaim() || PermissionNodeHandler.INSTANCE.perm(player, PermissionNodeHandler.ADMIN_BYPASS, true);
         return this.isAdminClaim() && player.hasPermissions(2);
@@ -398,10 +415,12 @@ public class Claim implements IPermissionContainer {
     }
 
     private boolean hasPerm(ResourceLocation perm) {
-        if (this.parentClaim() == null)
+        if (this.parentClaim() == null) {
             return this.permEnabled(perm) == 1;
-        if (this.permEnabled(perm) == -1)
+        }
+        if (this.permEnabled(perm) == -1) {
             return this.parentClaim().permEnabled(perm) == 1;
+        }
         return this.permEnabled(perm) == 1;
     }
 

--- a/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java
@@ -294,7 +294,7 @@ public class Claim implements IPermissionContainer {
     }
 
     /**
-     * Check if a player in a certain position owns a defined permission.
+     * Check if a player, in a certain position, has a defined permission.
      *
      * @param player  The player doing the action. Can be null
      * @param perm    Permission that is going to be checked
@@ -380,7 +380,7 @@ public class Claim implements IPermissionContainer {
     }
 
     /**
-     * Can a player ignore a specified permission.
+     * Can a permission be ignored for a specific player.
      *
      * @param player Player that is going to be checked.
      * @param perm   Permission that is going to be checked.

--- a/common/src/main/java/io/github/flemmli97/flan/gui/ClaimMenuScreenHandler.java
+++ b/common/src/main/java/io/github/flemmli97/flan/gui/ClaimMenuScreenHandler.java
@@ -71,7 +71,7 @@ public class ClaimMenuScreenHandler extends ServerOnlyScreenHandler<Claim> {
                 case 5 -> {
                     ItemStack stack = ServerScreenHelper.createStack(Items.OAK_SIGN,
                             ServerScreenHelper.coloredGuiText("flan.screenMenuClaimText", ChatFormatting.GOLD));
-                    if (!this.hasPerm(this.data, this.player, BuiltinPermission.EDITCLAIM))
+                    if (!this.hasPerm(this.data, this.player, BuiltinPermission.CLAIMMESSAGE))
                         ServerScreenHelper.addLore(stack, ServerScreenHelper.coloredGuiText("flan.screenNoPerm", ChatFormatting.DARK_RED));
                     this.slots.get(i).set(stack);
                 }


### PR DESCRIPTION
# What have i done
- Fixed issue #415 #413 by implementing a check for nonoverridable global permissions.
- Added some javadoc documentation for methods that ive touched.
- Set the proper permission for editing claim text in the ClaimMenuScreenHandler.java

# In depth technical explanation and reasoning
> This is an excerpt from issue #415 .
## Preamble, config.
The default config has this in global permissions.
```json
"globalDefaultPerms": {
    "*": {
      "flan:edit_potions": "ALLFALSE",
      "flan:flight": "ALLTRUE",
      "flan:lock_items": "ALLTRUE",
      "flan:may_flight": "ALLFALSE",
      "flan:mob_spawn": "ALLFALSE",
      "flan:no_hunger": "ALLFALSE",
      "flan:teleport": "ALLFALSE"
    }
  }
```
## Permission checking
I did some digging around as to how permissions are checked.
In the handler for the claim menu screen, this is the display that utilizes the same method:
https://github.com/Flemmli97/Flan/blob/b847939565b6ffa8c6d791f7f6cd97dfe60edd94/common/src/main/java/io/github/flemmli97/flan/gui/ClaimMenuScreenHandler.java#L64-L70

This is the line that does it in the click handler, same class:
https://github.com/Flemmli97/Flan/blob/b847939565b6ffa8c6d791f7f6cd97dfe60edd94/common/src/main/java/io/github/flemmli97/flan/gui/ClaimMenuScreenHandler.java#L133

If we go into that method and inject logging code for debug.
```java
private void logIfEditPoutions(ResourceLocation perm, String message){
        if(perm.toString().equals("flan:edit_potions")) Flan.LOGGER.info("canInterract({}, ...): {}",  perm.toString(), message);
    }

    @Override
    public boolean canInteract(ServerPlayer player, ResourceLocation perm, BlockPos pos, boolean message) {
        logIfEditPoutions(perm, "BEGIN");
        boolean realPlayer = player != null && player.getClass().equals(ServerPlayer.class);
        message = message && realPlayer && player.connection != null; //dont send messages to fake players
        //Delegate interaction to FAKEPLAYER perm if a fake player
        if (player != null && !realPlayer) {
            //Some mods use the actual user/placer/owner whatever of the fakeplayer. E.g. ComputerCraft
            //For those mods we dont pass them as fake players
            if (this.fakePlayers.contains(player.getUUID()))
                return true;
            if (!player.getUUID().equals(this.owner) && !this.playersGroups.containsKey(player.getUUID())) {
                perm = BuiltinPermission.FAKEPLAYER;
            }
        }
        InteractionResult res = ClaimEvents.INSTANCE.claimCheck(player, perm, pos);
        logIfEditPoutions(perm, "InteractionResult= " + res); //debug
        if (res != InteractionResult.PASS)
            return res != InteractionResult.FAIL;
        if (!this.isAdminClaim()) {
            Config.GlobalType global = ConfigHandler.CONFIG.getGlobal(this.level, perm);
            logIfEditPoutions(perm, "global.getValue= " + global.getValue()); //debug
            if (!global.canModify()) {

                if (global.getValue() || (player != null && this.playerBypassesPermission(player, perm))){
                    logIfEditPoutions(perm, "return true ");
                    return true;
                }
                if (message)
                    player.displayClientMessage(ClaimUtils.translatedText("flan.noPermissionSimple", ChatFormatting.DARK_RED), true);
                if (perm.equals(BuiltinPermission.FAKEPLAYER))
                    this.getOwnerPlayer().ifPresent(p -> PlayerClaimData.get(p).notifyFakePlayerInteraction(player, pos, this));
                logIfEditPoutions(perm, "return false "); //debug
                return false;
            }
            logIfEditPoutions(perm, "PASSED " + global.getValue()); //debug
            if (ConfigHandler.CONFIG.offlineProtectActivation != -1 && (LogoutTracker.getInstance(this.level.getServer()).justLoggedOut(this.getOwner()) || this.getOwnerPlayer().isPresent())) {
                return global == Config.GlobalType.NONE || global.getValue();
            }
        }
        if (PermissionManager.getInstance().isGlobalPermission(perm)) {
            for (Claim claim : this.subClaims) {
                if (claim.insideClaim(pos)) {
                    return claim.canInteract(player, perm, pos, message);
                }
            }
            if (this.hasPerm(perm))
                return true;
            if (message)
                player.displayClientMessage(ClaimUtils.translatedText("flan.noPermissionSimple", ChatFormatting.DARK_RED), true);
            if (perm.equals(BuiltinPermission.FAKEPLAYER))
                this.getOwnerPlayer().ifPresent(p -> PlayerClaimData.get(p).notifyFakePlayerInteraction(player, pos, this));
            return false;
        }
        if (this.playerBypassesPermission(player, perm))
            return true;
        if (!perm.equals(BuiltinPermission.EDITCLAIM) && !perm.equals(BuiltinPermission.EDITPERMS))
            for (Claim claim : this.subClaims) {
                if (claim.insideClaim(pos)) {
                    return claim.canInteract(player, perm, pos, message);
                }
            }
        if (this.playersGroups.containsKey(player.getUUID())) {
            Map<ResourceLocation, Boolean> map = this.permissions.get(this.playersGroups.get(player.getUUID()));
            if (map != null && map.containsKey(perm)) {
                if (map.get(perm))
                    return true;
                if (message)
                    player.displayClientMessage(ClaimUtils.translatedText("flan.noPermissionSimple", ChatFormatting.DARK_RED), true);
                if (perm.equals(BuiltinPermission.FAKEPLAYER))
                    this.getOwnerPlayer().ifPresent(p -> PlayerClaimData.get(p).notifyFakePlayerInteraction(player, pos, this));
                return false;
            }
        }
        if (this.hasPerm(perm))
            return true;
        if (message)
            player.displayClientMessage(ClaimUtils.translatedText("flan.noPermissionSimple", ChatFormatting.DARK_RED), true);
        if (perm.equals(BuiltinPermission.FAKEPLAYER))
            this.getOwnerPlayer().ifPresent(p -> PlayerClaimData.get(p).notifyFakePlayerInteraction(player, pos, this));
        return false;
    }
```
You will notice that at the end it returns true at:
https://github.com/Flemmli97/Flan/blob/b847939565b6ffa8c6d791f7f6cd97dfe60edd94/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java#L326-L327
This is according to the log you get in console thanks to the added loggers:
```txt
[16:21:43] [Server thread/INFO] (flan) canInterract(flan:edit_potions, ...): BEGIN
[16:21:43] [Server thread/INFO] (flan) canInterract(flan:edit_potions, ...): InteractionResult= Pass[]
[16:21:43] [Server thread/INFO] (flan) canInterract(flan:edit_potions, ...): global.getValue= false
[16:21:43] [Server thread/INFO] (flan) canInterract(flan:edit_potions, ...): return true 
```

According to that if statement and the situation where these checks are called it can be presumed that:
- the permission will be false (actually checked this with the inserted logger, refer to code block above)
- player **will not be null**
- `this.playerBypassesPermission(player, perm))` has to return true in order for the `return true` to be called

The aforementioned method doesnt check for global permissions, it will just return true if its the owner of the claim.
https://github.com/Flemmli97/Flan/blob/b847939565b6ffa8c6d791f7f6cd97dfe60edd94/common/src/main/java/io/github/flemmli97/flan/claim/Claim.java#L387-L388