### PR TITLE
Fix 2d claim display vertices

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/player/display/ClaimDisplay.java
+++ b/common/src/main/java/io/github/flemmli97/flan/player/display/ClaimDisplay.java
@@ -60,8 +60,8 @@ public class ClaimDisplay {
                 Height heightPos = getHeight(pos.getX(), pos.getZ(), height, chunkCache);
                 if (heightPos != null) {
                     if (heightPos.solid != heightPos.water)
-                        verticesNew.add(new BlockPos(box.minX(), heightPos.water, box.minZ()));
-                    verticesNew.add(new BlockPos(box.minX(), heightPos.solid, box.minZ()));
+                        verticesNew.add(new BlockPos(pos.getX(), heightPos.water, pos.getZ()));
+                    verticesNew.add(new BlockPos(pos.getX(), heightPos.solid, pos.getZ()));
                 }
             }
             vertices = verticesNew;


### PR DESCRIPTION
The claim corner vertices for 2d claim display all use the minX / minZ coordinates of the claim box, leading to weird claim display issues with multiple fake gold blocks from different corners stacked on top of eachother on the min corner of the claim.

This also makes the other corners incomplete.

An example of this:
<img width="2560" height="1369" alt="2026-05-06_14 30 39" src="https://github.com/user-attachments/assets/871c3a79-867f-4cb1-b5de-9468d6c7bf3c" />

How it should look (with the fix applied):
<img width="2560" height="1369" alt="2026-05-06_14 31 18" src="https://github.com/user-attachments/assets/eb295ed3-520b-47ba-b529-79af7f0b6a43" />
