### PR TITLE
fix: wrong enderpearl check

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/event/EntityInteractEvents.java
+++ b/common/src/main/java/io/github/flemmli97/flan/event/EntityInteractEvents.java
@@ -148,7 +148,7 @@ public class EntityInteractEvents {
                 if (proj instanceof ThrownEnderpearl) {
                     ClaimStorage storage = ClaimStorage.get((ServerLevel) proj.level());
                     IPermissionContainer claim = storage.getForPermissionCheck(proj.blockPosition());
-                    return claim.canInteract(player, BuiltinPermission.ENDERPEARL, proj.blockPosition(), true);
+                    return !claim.canInteract(player, BuiltinPermission.ENDERPEARL, proj.blockPosition(), true);
                 }
                 Entity hit = ((EntityHitResult) res).getEntity();
                 boolean fail = attackSimple(player, hit, true) != InteractionResult.PASS;


### PR DESCRIPTION
The output of the special ender pearl check in projectileHit was reversed incorrectly. This made it so ender pearls couldn't active when hit by other entities, even in unclaimed chunks.

This fixes it so that you can actually hit ender pearls with e.g. wind charges. This makes pearl catching actually possible.