### PR TITLE
Fix crash when typing an invalid id into the allow list screen

### DIFF
--- a/common/src/main/java/io/github/flemmli97/flan/claim/attachment/AllowedRegistryList.java
+++ b/common/src/main/java/io/github/flemmli97/flan/claim/attachment/AllowedRegistryList.java
@@ -86,11 +86,15 @@ public class AllowedRegistryList<T> {
     }
 
     public void addAllowedItem(String value) {
-        if (value.startsWith("#"))
-            this.addAllowedItem(Either.right(TagKey.create(this.registry.key(), Identifier.parse(value.substring(1)))));
-        else {
-            this.registry.getOptional(Identifier.parse(value))
-                    .ifPresent(direct -> this.addAllowedItem(Either.left(direct)));
+        if (value.startsWith("#")) {
+            Identifier id = Identifier.tryParse(value.substring(1));
+            if (id != null)
+                this.addAllowedItem(Either.right(TagKey.create(this.registry.key(), id)));
+        } else {
+            Identifier id = Identifier.tryParse(value);
+            if (id != null)
+                this.registry.getOptional(id)
+                        .ifPresent(direct -> this.addAllowedItem(Either.left(direct)));
         }
     }
 


### PR DESCRIPTION
The add button in the custom interact list screen feeds the anvil text straight into Identifier.parse, so any input that isn't a valid identifier (capital letters, spaces and so on) throws instead of being ignored. Saw it on my 1.21.1 server when someone typed a player name into the field, and the same code is on this branch.

```
net.minecraft.ResourceLocationException: Non [a-z0-9/._-] character in path of location: minecraft:LifeHaver69
    at io.github.flemmli97.flan.claim.attachment.AllowedRegistryList.addAllowedItem
    at io.github.flemmli97.flan.gui.CustomInteractListScreenHandler.lambda$handleSlotClicked$3
    at io.github.flemmli97.flan.gui.StringResultScreenHandler.method_7593
```

Switched to tryParse and ignore input that doesn't parse, which matches what already happens for ids that parse but aren't in the registry. :common:compileJava passes.